### PR TITLE
update dependencies Grunt and Bootstrap - set active class…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/morganfeeney/bootstrap-patterns.git"
+    "url": "https://github.com/morganfeeney/bootstrap-patterns"
   },
   "bugs": {
     "url": "https://github.com/morganfeeney/bootstrap-patterns/issues"

--- a/package.json
+++ b/package.json
@@ -5,21 +5,21 @@
   "author": "Morgan Feeney",
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer": "^6.0.3",
-    "bootstrap": "^4.0.0-alpha.2",
-    "grunt": "^0.4.5",
-    "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-nunjucks-2-html": "^1.0.4",
-    "grunt-postcss": "^0.6.0",
+    "autoprefixer": "^6.7.7",
+    "bootstrap": "^4.0.0-alpha.6",
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-nunjucks-2-html": "^3.0.0",
+    "grunt-postcss": "^0.8.0",
     "grunt-prettify": "^0.4.0",
-    "grunt-sass": "^1.2.0",
-    "load-grunt-tasks": "^3.1.0",
-    "time-grunt": "^1.1.0"
+    "grunt-sass": "^2.0.0",
+    "load-grunt-tasks": "^3.5.2",
+    "time-grunt": "^1.4.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/morganfeeney/bootstrap-patterns"
+    "url": "git+https://github.com/morganfeeney/bootstrap-patterns.git"
   },
   "bugs": {
     "url": "https://github.com/morganfeeney/bootstrap-patterns/issues"

--- a/src/html/components/nav.njk
+++ b/src/html/components/nav.njk
@@ -1,10 +1,12 @@
 {% import "macros/macro-search.njk" as macroSearch %}
 
-<div class="nav navbar-nav">
+<ul class="navbar-nav mr-auto">
   {% for item in navItems %}
+  <li class="nav-item {% if page_id == item.menu_item %}active{% endif %}">
     <a class="nav-item nav-link" href="{{ item.menu_item | lower | replace(" ", "") }}.html">{{ item.menu_item }}</a>
+  </li>
   {% endfor %}
+</ul>
   {% block navRight %}
     {{ macroSearch.search() }}
   {% endblock %}
-</div>

--- a/src/html/layouts/layout.njk
+++ b/src/html/layouts/layout.njk
@@ -9,8 +9,12 @@
   </head>
   <body class="{{ body_classes }}">
   <article>
-    <nav id="main-nav" class="container-fluid navbar navbar-dark bg-inverse {{ main_nav_classes }}">
-      <div class="container">
+    <nav class="navbar navbar-inverse bg-inverse navbar-toggleable-md {{ main_nav_classes }}">
+      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <a class="navbar-brand" href="#">Navbar</a>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
         {% block nav %}
           {% include "components/nav.njk" %}
         {% endblock %}

--- a/src/html/macros/macro-search.njk
+++ b/src/html/macros/macro-search.njk
@@ -1,6 +1,6 @@
 {% macro search(placeHolder="Search stuff...", buttonText="Search") %}
-  <form class="form-inline pull-xs-right">
-    <input class="form-control" type="text" placeholder="{{ placeHolder }}">
-    <button class="btn btn-success-outline" type="submit">{{ buttonText }}</button>
+  <form class="form-inline my-2 my-lg-0">
+    <input class="form-control mr-sm-2" type="text" placeholder="{{ placeHolder }}">
+    <button class="btn btn-outline-success my-2 my-sm-0" type="submit">{{ buttonText }}</button>
   </form>
 {% endmacro %}

--- a/src/html/partials/footer-scripts.njk
+++ b/src/html/partials/footer-scripts.njk
@@ -2,13 +2,3 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.2/js/tether.js"></script>
 <script type="text/javascript" src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
 <script src="http://localhost:35729/livereload.js"></script>
-<script type="text/javascript">
-  // var url = window.location;
-  // Will only work if string in href matches with location
-  //$('.nav a[href="'+ url +'"]').addClass('active');
-
-  // Will also work for relative and absolute hrefs
-  // $('.nav a').filter(function() {
-  //     return this.href == url;
-  // }).addClass('active');
-</script>

--- a/src/html/partials/footer-scripts.njk
+++ b/src/html/partials/footer-scripts.njk
@@ -3,12 +3,12 @@
 <script type="text/javascript" src="../node_modules/bootstrap/dist/js/bootstrap.js"></script>
 <script src="http://localhost:35729/livereload.js"></script>
 <script type="text/javascript">
-  var url = window.location;
+  // var url = window.location;
   // Will only work if string in href matches with location
   //$('.nav a[href="'+ url +'"]').addClass('active');
 
   // Will also work for relative and absolute hrefs
-  $('.nav a').filter(function() {
-      return this.href == url;
-  }).addClass('active');
+  // $('.nav a').filter(function() {
+  //     return this.href == url;
+  // }).addClass('active');
 </script>

--- a/src/html/templates/index.html
+++ b/src/html/templates/index.html
@@ -2,6 +2,7 @@
 
 {% set base_path = "../" %}
 {% set page_title = "Home page | Bootstrap Patterns" %}
+{% set page_id = "Index" %}
 {% set page_description = "This is the home page" %}
 {% set main_header_classes = "jumbotron jumbotron-fluid" %}
 

--- a/src/html/templates/page1.html
+++ b/src/html/templates/page1.html
@@ -2,6 +2,7 @@
 
 {% set base_path = "../" %}
 {% set page_title = "Page 1 | Bootstrap Patterns" %}
+{% set page_id = "Page 1" %}
 {% set page_description = "This is page one." %}
 {% set main_header_classes = "m-t-2 m-b-2" %}
 

--- a/src/html/templates/page2.html
+++ b/src/html/templates/page2.html
@@ -2,6 +2,7 @@
 
 {% set base_path = "../" %}
 {% set page_title = "Page 2 | Bootstrap Patterns" %}
+{% set page_id = "Page 2" %}
 {% set page_description = "This is page two." %}
 {% set main_header_classes = "m-t-2 m-b-2" %}
 


### PR DESCRIPTION
In this PR I updated the dependencies for Grunt, and others as well in `package.json` because after NPM first install running the `grunt` command Grunt wouldn't run and generates an error. Bootstraps navbar needed some additional (updated) markup too with the new version.

I opted for setting an active class on the nav's list-items (like in Bootstrap) ISO on the link _in the templates_ ISO in javaScript. Using the [comparison](https://mozilla.github.io/nunjucks/templating.html#comparisons) operator `==`  here within an if-statement. This works when the values of the two variables `page_id` (in this example from `html/templates/page1.html`) and  `menu_item` from the for-loop in `html/components/nav.njk` _match_, ... and because of the way these templates render:

> Because assignments outside of blocks in child templates are global and executed before the layout template is evaluated it’s possible to define the active menu item in the child template:

In `html/templates/page1.html`:
```nunjucks
{% set page_id = "Page 1" %}   
```

In `html/components/nav.njk`:
```nunjucks
  <li class="nav-item {% if page_id == item.menu_item %}active{% endif %}">
```